### PR TITLE
Define min php version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         }
     },
     "require": {
+        "php": ">=5.4.0",
         "zendframework/zend-diactoros": "^1.3",
         "php-pm/php-pm": "*"
     },


### PR DESCRIPTION
Used 5.4 because we use session_status() and array short notation.
